### PR TITLE
fixed gen_mapping methods

### DIFF
--- a/deepxml/tools/surrogate_mapping.py
+++ b/deepxml/tools/surrogate_mapping.py
@@ -87,9 +87,9 @@ class SurrogateMapping(object):
             self.map_none()    
         elif self.method == 1:
             self.map_on_cluster(features, labels)    
-        elif self.method == 1:
-            self.map_on_frequency(labels)
         elif self.method == 2:
+            self.map_on_frequency(labels)
+        elif self.method == 3:
             self.map_on_topk(labels)
         else:
             pass


### PR DESCRIPTION
there was a typo where it was checking if self.method == 1 twice, i assume it should match the class documentation where methods are either 0, 1, 2, or 3